### PR TITLE
Use only two dynos instead of 4

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,4 +1,2 @@
-daphne: daphne coinpricemonitor.asgi:channel_layer --port 8000 --bind 0.0.0.0 -v2
-coin_worker: python manage.py runworker --settings=coinpricemonitor.settings -v2
-celery_worker: celery -A coinpricemonitor.celeryconfig worker -l info
-celery_beat: celery -A coinpricemonitor.celeryconfig beat -l info
+coin_worker: python manage.py runserver --settings=coinpricemonitor.settings
+celery_worker: celery -A coinpricemonitor.celeryconfig worker --beat -l info


### PR DESCRIPTION
Instead to use four dynos, it's better to divide them in two groups, one that will run the server, which is the `coin_worker` and the other one is going to run celery, which is the `celery_worker`.